### PR TITLE
inclusão do Bogus e ajuste nos métodos de teste

### DIFF
--- a/Domain/Validations/CreateContactValidation.cs
+++ b/Domain/Validations/CreateContactValidation.cs
@@ -13,7 +13,8 @@ namespace Domain.Validations
 
             RuleFor(e => e.Phone)
                 .NotEmpty()
-                .NotNull();
+                .NotNull()
+                .Matches(@"^\d{8,9}$").WithMessage("'Phone' number must contain 8 or 9 digits."); ;
         }
     }
 }

--- a/TechChallenge.Tests/Entitiy/ContactBuilder.cs
+++ b/TechChallenge.Tests/Entitiy/ContactBuilder.cs
@@ -1,0 +1,22 @@
+﻿using Bogus;
+using Bogus.DataSets;
+using Domain;
+using Domain.DTOs;
+
+namespace TechChallenge.Tests.Entitiy;
+
+public class ContactBuilder
+{
+    public static ContactDTO Build()
+    {
+        var contact = new Faker<ContactDTO>()
+            .RuleFor(c => c.Name, (f) => f.Person.FullName)
+            //.RuleFor(u => u.Phone, f =>  f.Phone.PhoneNumber("!!9########")
+            //    .Replace("!", $"{f.Random.Int(min: 1, max: 9)}"))
+            .RuleFor(u => u.Phone, f => string.Concat(f.Random.Int(10, 99), f.Phone.PhoneNumber("9########"))
+                .Replace("!", $"{f.Random.Int(min: 1, max: 9)}"))
+            .RuleFor(c => c.Email, (f) => f.Internet.Email(f.Person.FullName));
+
+        return contact;
+    }
+}

--- a/TechChallenge.Tests/Entitiy/ContactBuilder.cs
+++ b/TechChallenge.Tests/Entitiy/ContactBuilder.cs
@@ -11,8 +11,6 @@ public class ContactBuilder
     {
         var contact = new Faker<ContactDTO>()
             .RuleFor(c => c.Name, (f) => f.Person.FullName)
-            //.RuleFor(u => u.Phone, f =>  f.Phone.PhoneNumber("!!9########")
-            //    .Replace("!", $"{f.Random.Int(min: 1, max: 9)}"))
             .RuleFor(u => u.Phone, f => string.Concat(f.Random.Int(10, 99), f.Phone.PhoneNumber("9########"))
                 .Replace("!", $"{f.Random.Int(min: 1, max: 9)}"))
             .RuleFor(c => c.Email, (f) => f.Internet.Email(f.Person.FullName));

--- a/TechChallenge.Tests/Models/ContactTests.cs
+++ b/TechChallenge.Tests/Models/ContactTests.cs
@@ -1,7 +1,5 @@
 using Domain;
-using Domain.DTOs;
-using FluentValidation.Results;
-using Xunit;
+using TechChallenge.Tests.Entitiy;
 
 namespace TechChallenge.Tests.Domain
 {
@@ -11,34 +9,24 @@ namespace TechChallenge.Tests.Domain
         public void Create_ShouldReturnContact_WhenContactDTOIsValid()
         {
             // Arrange
-            var contactDto = new ContactDTO
-            {
-                Name = "John Doe",
-                Phone = "12123456789",
-                Email = "john@example.com"
-            };
+            var contactDto = ContactBuilder.Build();
 
             // Act
             var contact = Contact.Create(contactDto);
 
             // Assert
             Assert.NotNull(contact);
-            Assert.Equal("John Doe", contact.Name);
-            Assert.Equal("123456789", contact.Phone);
-            Assert.Equal("john@example.com", contact.Email);
-            Assert.Equal(12, contact.DDDId);
+            Assert.Equal(contactDto.Name, contact.Name);
+            Assert.Equal(contactDto.Phone, string.Concat(contact.DDDId.ToString(), contact.Phone));
+            Assert.Equal(contactDto.Email, contact.Email);
         }
 
         [Fact]
-        public void Create_ShouldHaveValidationErrors_WhenContactDTOIsInvalid()
+        public void Create_ShouldHaveValidationErrors_WhenEmailContactDTOIsInvalid()
         {
             // Arrange
-            var contactDto = new ContactDTO
-            {
-                Name = "John Doe",
-                Phone = "invalid-phone",
-                Email = "invalid-email"
-            };
+            var contactDto = ContactBuilder.Build();
+            contactDto.Email = contactDto.Email.Replace("@", "");
 
             // Act
             var contact = Contact.Create(contactDto);
@@ -46,6 +34,26 @@ namespace TechChallenge.Tests.Domain
             // Assert
             Assert.NotNull(contact);
             Assert.NotEmpty(contact.ValidationResult.Errors);
+            Assert.True(contact.ValidationResult.Errors.Count() == 1);
+            Assert.Equal("'Email' is not a valid email address.", contact.ValidationResult.Errors[0].ErrorMessage);
         }
+
+        [Fact]
+        public void Create_ShouldHaveValidationErrors_WhenPhoneContactDTOIsInvalid()
+        {
+            // Arrange
+            var contactDto = ContactBuilder.Build();
+            contactDto.Phone = contactDto.Phone[3..];
+
+            // Act
+            var contact = Contact.Create(contactDto);
+
+            // Assert
+            Assert.NotNull(contact);
+            Assert.NotEmpty(contact.ValidationResult.Errors);
+            Assert.True(contact.ValidationResult.Errors.Count() == 1);
+            Assert.Equal("'Phone' number must contain 8 or 9 digits.", contact.ValidationResult.Errors[0].ErrorMessage);
+        }
+        
     }
 }

--- a/TechChallenge.Tests/TechChallenge.Tests.csproj
+++ b/TechChallenge.Tests/TechChallenge.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Bogus" Version="35.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- inclusão Bogus para retornar dados dinâmicos do contato
- separação de testes para email e telefone inválidos
  no antigo método **Create_ShouldHaveValidationErrors_WhenContactDTOIsInvalid** ele primeiro pega o erro de invalid ddd, mas depois era substituído pelo erro de e-mail invalido gerado pelo CreateContactValidation
  não retornava dois erros na lista do ValidationResult, somente o último.
  Por isso fiz uma separação de testes um para e-mail inválido e outro para telefone inválido
- atualização no RuleFor do Telefone para aceitar números entre 8 ou 9 dígitos  
  pois quando passava texto para essa propriedade